### PR TITLE
Rename WebServer -> BleeperWebServer

### DIFF
--- a/src/ConfigurationInterface/WebServer/BleeperWebServer.cpp
+++ b/src/ConfigurationInterface/WebServer/BleeperWebServer.cpp
@@ -1,14 +1,14 @@
-#include "ConfigurationInterface/WebServer/WebServer.h"
+#include "ConfigurationInterface/WebServer/BleeperWebServer.h"
 #include "Configuration/ConfigurationDictionary.h"
 #include "Bleeper/BleeperClass.h"
 #include "Helpers/Logger.h"
 #include "ConfigurationInterface/WebServer/WebPage.h"
 
-WebServer::WebServer(int port) {
+BleeperWebServer::BleeperWebServer(int port) {
   this->port = port;
 }
 
-String WebServer::buildPage(const std::vector<StringConvertibleVariable*> & vars) {
+String BleeperWebServer::buildPage(const std::vector<StringConvertibleVariable*> & vars) {
   Log("Page requested");
   String first = "<!DOCTYPE html><title>Bleeper</title><meta content=\"width=device-width,user-scalable=no\"name=viewport><link href=style rel=stylesheet><link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css?family=Righteous\"><script src=script></script><div id=cf><h1>Bleeper</h1>";
   String middle = "";
@@ -25,7 +25,7 @@ String WebServer::buildPage(const std::vector<StringConvertibleVariable*> & vars
   return first + middle + last;
 }
 
-void WebServer::saveValues(const std::map<String, String> & args) {
+void BleeperWebServer::saveValues(const std::map<String, String> & args) {
   if (args.size() == 0) return;
   ConfigurationDictionary params;
   for(const auto & arg: args) {
@@ -36,10 +36,10 @@ void WebServer::saveValues(const std::map<String, String> & args) {
   Log("Configs saved!");
 }
 
-const char* WebServer::getJS() {
+const char* BleeperWebServer::getJS() {
   return JS;
 }
 
-const char* WebServer::getStyle() {
+const char* BleeperWebServer::getStyle() {
   return CSS;
 }

--- a/src/ConfigurationInterface/WebServer/BleeperWebServer.h
+++ b/src/ConfigurationInterface/WebServer/BleeperWebServer.h
@@ -11,11 +11,11 @@
 #define CONTENT_TYPE_JS "application/javascript"
 #define CONTENT_TYPE_CSS "text/css"
 
-class WebServer: public ConfigurationInterface {
+class BleeperWebServer : public ConfigurationInterface {
 protected:
   int port;
 public:
-  WebServer(int port);
+  BleeperWebServer(int port);
   virtual void init() = 0;
   virtual void handle() = 0;
   virtual String buildPage(const std::vector<StringConvertibleVariable*> &);

--- a/src/ConfigurationInterface/WebServer/ESP32/ESP32DefaultWebServer.cpp
+++ b/src/ConfigurationInterface/WebServer/ESP32/ESP32DefaultWebServer.cpp
@@ -5,7 +5,7 @@
 #include "Helpers/Logger.h"
 #include <functional>
 
-ESP32DefaultWebServer::ESP32DefaultWebServer(int port): WebServer(port) {
+ESP32DefaultWebServer::ESP32DefaultWebServer(int port): BleeperWebServer(port) {
   server = NULL;
 }
 

--- a/src/ConfigurationInterface/WebServer/ESP32/ESP32DefaultWebServer.h
+++ b/src/ConfigurationInterface/WebServer/ESP32/ESP32DefaultWebServer.h
@@ -4,14 +4,14 @@
 
 #include "Arduino.h"
 #include <WiFiServer.h>
-#include "ConfigurationInterface/WebServer/WebServer.h"
+#include "ConfigurationInterface/WebServer/BleeperWebServer.h"
 #include "ConfigurationInterface/WebServer/ESP32/HTTPRequest.h"
 #include <functional>
 #include <map>
 
 typedef std::function<void(HTTPRequest & request, WiFiClient &)> RouteHandler;
 
-class ESP32DefaultWebServer: public WebServer {
+class ESP32DefaultWebServer: public BleeperWebServer {
 protected:
   WiFiServer* server;
   std::map<String, RouteHandler> router;

--- a/src/ConfigurationInterface/WebServer/ESP8266/ESP8266DefaultWebServer.cpp
+++ b/src/ConfigurationInterface/WebServer/ESP8266/ESP8266DefaultWebServer.cpp
@@ -7,7 +7,7 @@
 #include <map>
 #include "Helpers/Logger.h"
 
-ESP8266DefaultWebServer::ESP8266DefaultWebServer(int port): WebServer(port) {
+ESP8266DefaultWebServer::ESP8266DefaultWebServer(int port): BleeperWebServer(port) {
   server = NULL;
 }
 

--- a/src/ConfigurationInterface/WebServer/ESP8266/ESP8266DefaultWebServer.h
+++ b/src/ConfigurationInterface/WebServer/ESP8266/ESP8266DefaultWebServer.h
@@ -4,9 +4,9 @@
 
 #include "Arduino.h"
 #include <ESP8266WebServer.h>
-#include "ConfigurationInterface/WebServer/WebServer.h"
+#include "ConfigurationInterface/WebServer/BleeperWebServer.h"
 
-class ESP8266DefaultWebServer: public WebServer {
+class ESP8266DefaultWebServer: public BleeperWebServer {
 protected:
   ESP8266WebServer* server;
   void handleRoot();


### PR DESCRIPTION
@dernster, starting another embedded project, and wanted to take the opportunity to use Bleeper!

Ran into an issue with a naming conflict with another library.  Renaming `WebServer` -> `BleeperWebServer` fixed it for me.