### PR TITLE
Add baudRate option to verbose()

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Config C;
 void setup() {
 
   Bleeper
-    .verbose()
+    .verbose(115200)
     .configuration
       .set(&C)
       .addObserver(new CalibrationObserver(), {&C.leds.calibration})

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -38,7 +38,7 @@ public:
 void setup() {
 
   Bleeper
-    .verbose()
+    .verbose(115200)
     .configuration
       .set(&C)
       .addObserver(new MyObserver(), {&C.wifi.network.port})

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],
-  "version": "1.0.4"
+  "version": "1.1.0"
 }

--- a/src/Bleeper/BleeperClass.cpp
+++ b/src/Bleeper/BleeperClass.cpp
@@ -33,8 +33,9 @@ void BleeperClass::handle() {
 
 }
 
-BleeperClass& BleeperClass::verbose() {
+BleeperClass& BleeperClass::verbose(int baudRate) {
   Logger::verbose = true;
+  Logger::baudRate = baudRate;
   return *this;
 }
 

--- a/src/Bleeper/BleeperClass.cpp
+++ b/src/Bleeper/BleeperClass.cpp
@@ -33,6 +33,11 @@ void BleeperClass::handle() {
 
 }
 
+BleeperClass& BleeperClass::verbose() {
+    Logger::verbose = true;
+    return *this;
+}
+
 BleeperClass& BleeperClass::verbose(int baudRate) {
   Logger::verbose = true;
   Logger::baudRate = baudRate;

--- a/src/Bleeper/BleeperClass.h
+++ b/src/Bleeper/BleeperClass.h
@@ -25,7 +25,7 @@ public:
   void handle();
   void init();
   void init(bool loadFromStorage);
-  BleeperClass& verbose();
+  BleeperClass& verbose(int baudRate);
 
   class Chainable {
   public:

--- a/src/Bleeper/BleeperClass.h
+++ b/src/Bleeper/BleeperClass.h
@@ -25,6 +25,7 @@ public:
   void handle();
   void init();
   void init(bool loadFromStorage);
+  BleeperClass& verbose();
   BleeperClass& verbose(int baudRate);
 
   class Chainable {

--- a/src/Helpers/Logger.cpp
+++ b/src/Helpers/Logger.cpp
@@ -1,4 +1,5 @@
 #include "Logger.h"
 
 bool Logger::verbose = false;
+int Logger::baudRate = 115200;
 bool Logger::serialInitialized = false;

--- a/src/Helpers/Logger.h
+++ b/src/Helpers/Logger.h
@@ -7,9 +7,10 @@ class Logger {
 public:
   static bool verbose;
   static bool serialInitialized;
+  static int  baudRate;
   static void print(String msg) {
     if (!serialInitialized) {
-      Serial.begin(115200);
+      Serial.begin(baudRate);
       while (!Serial) yield();
       serialInitialized = true;
     }


### PR DESCRIPTION
In scenarios where the user sets a different baud rate for their
serial connection, the usage of the logger in this library causes
any subsequent data to be out of sync. Therefore, adding the
`baudRate` parameter to verbose will allow users to configure this.